### PR TITLE
Provision user and schema on a MariaDB instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ansibleplaybookbundle/apb-base
+
+LABEL "com.redhat.apb.spec"=\
+"dmVyc2lvbjogMS4wCm5hbWU6IGRiYWFzLW1hcmlhZGItYXBiCmRlc2NyaXB0aW9uOiBNYXJpYURC\
+IGFzIGEgU2VydmljZQpiaW5kYWJsZTogVHJ1ZQphc3luYzogb3B0aW9uYWwKbWV0YWRhdGE6CiAg\
+ZGlzcGxheU5hbWU6IERCYWFTIC0gTWFyaWFEQiAoQVBCKQogIGRlcGVuZGVuY2llczogW10KICBw\
+cm92aWRlckRpc3BsYXlOYW1lOiBBUFBVaU8KcGxhbnM6CiAgLSBuYW1lOiBkZWZhdWx0CiAgICBk\
+ZXNjcmlwdGlvbjogVGhpcyBkZWZhdWx0IHBsYW4gY3JlYXRlcyBhIERCIHVzZXIgYW5kIHNjaGVt\
+YQogICAgZnJlZTogVHJ1ZQogICAgbWV0YWRhdGE6IHt9CiAgICBwYXJhbWV0ZXJzOiBbXQo="
+
+
+
+COPY playbooks /opt/apb/actions
+COPY . /opt/ansible/roles/dbaas-mariadb-apb
+RUN chmod -R g=u /opt/{ansible,apb} \
+ && yum -y install MySQL-python python-mysqldb mysql && yum clean all
+
+USER apb

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+DOCKERHOST = docker.io
+DOCKERORG = mariadb-apb
+IMAGENAME = mariadb
+TAG = latest
+USER=$(shell id -u)
+PWD=$(shell pwd)
+build_and_push: apb_build docker_push apb_push
+
+.PHONY: apb_build
+apb_build:
+	apb prepare
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) .
+
+.PHONY: docker_push
+docker_push:
+	docker push $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG)
+
+.PHONY: apb_push
+apb_push:
+	apb push

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# MariaDB as a Service APB
+
+This Ansible playbook bundle provisions users and databases on a existing MariaDB instance.
+
+## Installation
+To provide the admin user credentials to connect to the MariaDB, a secret with the name `dbaas-db-credentials` needs to exist in the Ansible service broker namespace:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dbaas-db-credentials
+type: Opaque
+stringData:
+  mariadb_hostname: db.maria.com
+  mariadb_password: myPassword
+  mariadb_port: '3306'
+  mariadb_user: root
+```
+The Ansible service broker needs to be configured to mount the secret in provisioner pods. Add the following section to the Ansible service broker configuration (ConfigMap):
+```yaml
+secrets:
+- title: DBaaS database credentials
+  secret: dbaas-db-credentials
+  apb_name: localregistry-dbaas-mariadb-apb
+```
+
+## Development environment
+You can use [minishift](https://github.com/minishift/minishift) with the [Ansible Service Broker Addon](https://github.com/minishift/minishift-addons/tree/master/add-ons/ansible-service-broker) to run a local OpenShift installation with the Ansible service broker to test APBs:
+```bash
+MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--service-catalog" --openshift-version v3.9.0
+
+minishift addons install <path_to_addon>
+minishift addons apply ansible-service-broker
+```
+
+Install the [APB CLI](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#installing-the-apb-tool) on your machine. The easiest way is to run it in a Docker container via the provided [helper script](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/scripts/apb-docker-run.sh).
+
+## Release
+An automatic Docker build is set up for this repository. If you change stuff in `apb.yml` don't forget to run `apb prepare` before committing.

--- a/apb.yml
+++ b/apb.yml
@@ -1,0 +1,15 @@
+version: 1.0
+name: dbaas-mariadb-apb
+description: MariaDB as a Service
+bindable: True
+async: optional
+metadata:
+  displayName: DBaaS - MariaDB (APB)
+  dependencies: []
+  providerDisplayName: APPUiO
+plans:
+  - name: default
+    description: This default plan creates a DB user and schema
+    free: True
+    metadata: {}
+    parameters: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+# Defaults for values we could expect from a broker
+_apb_plan_id: default
+_apb_service_class_id: 0
+_apb_service_instance_id: 0
+
+app_name: "mariadb-{{ _apb_service_instance_id }}"

--- a/playbooks/deprovision.yml
+++ b/playbooks/deprovision.yml
@@ -1,0 +1,12 @@
+- name: mariadb-apb playbook to deprovision the application
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    apb_action: deprovision
+  roles:
+  - role: ansible.kubernetes-modules
+    install_python_requirements: no
+  - role: ansibleplaybookbundle.asb-modules
+  - role: dbaas-mariadb-apb
+    playbook_debug: false

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -1,0 +1,12 @@
+- name: mariadb-apb playbook to provision the application
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    apb_action: provision
+  roles:
+  - role: ansible.kubernetes-modules
+    install_python_requirements: no
+  - role: ansibleplaybookbundle.asb-modules
+  - role: dbaas-mariadb-apb
+    playbook_debug: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+- name: update last operation
+  asb_last_operation:
+    description: "0%: Starting"
+
+- set_fact:
+    ensure_state: "{{ (apb_action == 'provision') | ternary('present', 'absent') }}"
+    secrets_path: "/etc/apb-secrets/apb-dbaas-db-credentials"
+
+- name: read DB credentials
+  set_fact:
+    mariadb_hostname: "{{ lookup('file', secrets_path ~ '/mariadb_hostname') }}"
+    mariadb_port: "{{ lookup('file', secrets_path ~ '/mariadb_port') }}"
+    mariadb_user: "{{ lookup('password', secrets_path ~ '/mariadb_user') }}"
+    mariadb_password: "{{ lookup('password', secrets_path ~ '/mariadb_password') }}"
+
+- name: generate DB credentials
+  when: apb_action == 'provision'
+  set_fact:
+    create_db_name: "{{ lookup('password', '/tmp/_name length=5 chars=ascii_letters') }}"
+    create_db_user: "{{ lookup('password', '/tmp/_user length=5 chars=ascii_letters') }}"
+    create_db_password: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters') }}"
+
+- name: get generated DB credentials
+  when: apb_action == 'deprovision'
+  set_fact:
+    create_db_name: "{{ _apb_provision_creds.DB_NAME }}"
+    create_db_user: "{{ _apb_provision_creds.DB_USER }}"
+    create_db_password: "{{ _apb_provision_creds.DB_PASSWORD }}"
+
+- name: "{{ apb_action }} database"
+  mysql_db:
+    state: "{{ ensure_state }}"
+    name: "{{ create_db_name }}"
+    login_host: "{{ mariadb_hostname }}"
+    login_port: "{{ mariadb_port }}"
+    login_user: "{{ mariadb_user }}"
+    login_password: "{{ mariadb_password }}"
+
+- name: update last operation
+  asb_last_operation:
+    description: "50%: {{ apb_action }} database '{{ create_db_name }}'"
+
+- name: "{{ apb_action }} user"
+  mysql_user:
+    state: "{{ ensure_state }}"
+    name: "{{ create_db_user }}"
+    password: "{{ create_db_password }}"
+    priv: "{{ create_db_name }}.*:ALL"
+    host: "%"
+    login_host: "{{ mariadb_hostname }}"
+    login_port: "{{ mariadb_port }}"
+    login_user: "{{ mariadb_user }}"
+    login_password: "{{ mariadb_password }}"
+
+- name: update last operation
+  asb_last_operation:
+    description: "75%: {{ apb_action }} user '{{ create_db_user }}'"
+
+- name: "{{ apb_action }} OpenShift service"
+  k8s_v1_service:
+    state: "{{ ensure_state }}"
+    name: "{{ app_name }}"
+    namespace: "{{ namespace }}"
+    type: ExternalName
+    external_name: "{{ mariadb_hostname }}"
+
+- when: apb_action == 'provision'
+  name: Encode bind credentials
+  asb_encode_binding:
+    fields:
+      DB_TYPE: mariadb
+      DB_NAME: "{{ create_db_name }}"
+      DB_HOST: "{{ app_name }}"
+      DB_PORT: "{{ mariadb_port }}"
+      DB_USER: "{{ create_db_user }}"
+      DB_PASSWORD: "{{ create_db_password }}"
+
+- name: update last operation
+  asb_last_operation:
+    description: "100%: Done"


### PR DESCRIPTION
This is the initial version of the DBaaS Ansible playbook bundle. It
creates a user and schema on an existing MariaDB server. The
credentials are saved in a secret, ready to be used by applications.